### PR TITLE
add payer-move func and test-option for start func

### DIFF
--- a/game.rkt
+++ b/game.rkt
@@ -42,14 +42,19 @@
 (define frame64 (bitmap/file "frame64.bmp"))
 
 ;;ゲームスタート
-(define demo 'demo)
+(define demo "demo")
+(define test "test")
 (define (start . option)
   (cond ((null? option)
          (big-bang WORLD-ENVIROMENT
                    (to-draw display-contents)
                    (on-key key-action)))
-        ((= (car option) demo)
+        ((string=? (car option) demo)
          (big-bang WORLD-ENVIROMENT
+                   (to-draw display-contents)
+                   (on-key key-action)))
+        ((string=? (car option) test)
+         (big-bang (cons (cadr option) (cdr WORLD-ENVIROMENT))
                    (to-draw display-contents)
                    (on-key key-action)))
         (else (error "undefined option:" option))))
@@ -124,7 +129,7 @@
                         ((string=? dir "right") (cons (+ cur-x 1) cur-y)))))
     (list (screen-type env)
           (stage-selecting env)
-          (new-pos)
+          new-pos
           (stage-state-list env)
           (pause-state-list env)
           (stage-result env))))


### PR DESCRIPTION
## 目的
ステージ用の関数の制作と特定の場面をテストするためのテストオプション

## 編集内容の概要
- プレーヤーが移動するための関数の外枠を作った
- (start test 場面番号)で指定した場面からスタートできるようにした

## 不安な部分

## 保留部分
