### PR TITLE
fix: push object counted 2 steps

### DIFF
--- a/game.rkt
+++ b/game.rkt
@@ -424,7 +424,7 @@
            (if (eq? (take-element2 field-data next-pos) 0)
                (edit env
                      stage (edit stage-env
-                                 0 (dec-remain-act 2)
+                                 0 (dec-remain-act 1)
                                  3 (change-element2
                                     (change-element2 field-data new-pos 0)
                                     next-pos 'o)))


### PR DESCRIPTION
## 目的
押せる壁が2ステップ消費してたバグの修正

## 編集内容の概要
* データ構造を直したときに引数が2になってたから1に戻した

## 不安な部分


## 保留部分

